### PR TITLE
Defuse the BOM

### DIFF
--- a/src/reuse/_annotate.py
+++ b/src/reuse/_annotate.py
@@ -103,8 +103,14 @@ def add_header_to_file(
             path.touch()
             comment_style = EmptyCommentStyle
 
+    # Take care when handling this file to strip a byte-order mark (BOM) before
+    # handing off to the rest of the code. If there is one, it will be put back
+    # in when the file is written out.
     with open(path, "r", encoding="utf-8", newline="") as fp:
         text = fp.read()
+        has_bom = text.startswith("\ufeff")
+        if has_bom:
+            text = text[1:]
 
     # Ideally, this check is done elsewhere. But that would necessitate reading
     # the file contents before this function is called.
@@ -161,6 +167,8 @@ def add_header_to_file(
         result = 1
     else:
         with open(path, "w", encoding="utf-8", newline=line_ending) as fp:
+            if has_bom:
+                fp.write("\ufeff")
             fp.write(output)
         # TODO: This may need to be rephrased more elegantly.
         out.write(_("Successfully changed header of {path}").format(path=path))


### PR DESCRIPTION
Handle a byte order mark at the base level of the `add_header_to_file` function; if one is detected, it's stripped before other text processing _and then put back_ when writing the file out. It's a bit messy because Python's BOM-auto-stripping codec doesn't provide a way to detect whether it actually stripped anything...

I've made no attempt to handle UTF-16 or UTF-32. That would be... a bigger job.