### PR TITLE
186 create gh action workflow to build container

### DIFF
--- a/.github/workflows/docker_ghrc.yaml
+++ b/.github/workflows/docker_ghrc.yaml
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: 2026 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+#
+# SPDX-FileCopyrightText: 2026 University of Manchester
+#
+# SPDX-License-Identifier: apache-2.0
 
 name: Create and publish Debian Docker image to GitHub Container Registry
 

--- a/.github/workflows/docker_ghrc.yaml
+++ b/.github/workflows/docker_ghrc.yaml
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
+# SPDX-FileCopyrightText: 2022 Carmen Bianca Bakker <carmenbianca@fsfe.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/.github/workflows/docker_ghrc.yaml
+++ b/.github/workflows/docker_ghrc.yaml
@@ -2,3 +2,70 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+name: Create and publish Debian Docker image to GitHub Container Registry
+
+on:
+  push:
+    # Tags will carry the tag's version, e.g. v1.2.3:
+    # - 1.2.3
+    # - 1.2
+    # - 1 (not with 0 though)
+    # - latest"
+    tags:
+      - "v*.*.*"
+  # Manually trigger the workflow from the Actions tab in GitHub
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+    build-and-push-image:
+      runs-on: ubuntu-24.04
+      permissions:
+        contents: read
+        packages: write
+        attestations: write
+        id-token: write
+    
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        
+        - name: Setup Docker Buildx
+          uses: docker/setup-buildx-action@v1
+        
+        - name: Log in to GitHub Container Registry
+          uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+          with:
+            registry: ${{ env.REGISTRY }}
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+      
+        - name: Extract metadata (tags, labels) for Docker
+          id: meta
+          uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+          with:
+            images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      
+        # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+        # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see [Usage](https://github.com/docker/build-push-action#usage) in the README of the `docker/build-push-action` repository.
+        # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+        - name: Build and push Docker image
+          id: push  
+          uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+          with:
+            context: .
+            file: ./Dockerfile-debian
+            push: true
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
+        
+        # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
+        - name: Generate artifact attestation
+          uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+          with:
+            subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+            subject-digest: ${{ steps.push.outputs.digest }}
+            push-to-registry: true

--- a/.github/workflows/docker_ghrc.yaml
+++ b/.github/workflows/docker_ghrc.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Free Software Foundation Europe e.V. <https://fsfe.org>
-# SPDX-FileCopyrightText: 2022 Carmen Bianca Bakker <carmenbianca@fsfe.org>
+# SPDX-FileCopyrightText: 2026 Free Software Foundation Europe e.V. <https://fsfe.org>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
+

--- a/.github/workflows/docker_ghrc.yaml
+++ b/.github/workflows/docker_ghrc.yaml
@@ -38,7 +38,7 @@ jobs:
           uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         
         - name: Setup Docker Buildx
-          uses: docker/setup-buildx-action@v1
+          uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1
         
         - name: Log in to GitHub Container Registry
           uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate building and publishing a Debian-based Docker image to the GitHub Container Registry. The workflow is triggered on version tag pushes and manual dispatch, and it includes steps for building, tagging, pushing the image, and generating supply chain security attestations.

Includes:
- Added automate building and publishing a Debian-based Docker image to GitHub Container Registry, triggered on version tags and manual workflow dispatch.
- Configured the workflow to use Docker Buildx for multi-platform builds, extract metadata for tagging and labeling, and push the image using the repository's `Dockerfile-debian`.
- Implemented artifact attestation generation.